### PR TITLE
 Allow to configure Maximum Transmission Units

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -23,9 +23,6 @@ orbs:
           otp:
             description: OTP release to used by the job
             type: string
-          codecov_flag:
-            description: String the coverage reports are grouped by
-            type: string
         executor:
           name: elixir
           elixir: <<parameters.elixir>>
@@ -43,16 +40,7 @@ orbs:
                 - deps-<<parameters.elixir>>-<<parameters.otp>>-{{ checksum "mix.lock" }}
                 - deps-<<parameters.elixir>>-<<parameters.otp>>
           - run: mix deps.get
-          - run: mix coveralls.json
           - run: mix dialyzer --halt-exit-status
-          - run:
-              name: Install curl
-              command: apk add --no-cache curl
-          - run:
-              name: Upload coverage report
-              command: |
-                bash <(curl -s https://codecov.io/bash) \
-                  -F <<parameters.codecov_flag>>
           - save_cache:
               key: dialyzer-PLT-<<parameters.elixir>>-<<parameters.otp>>-{{ checksum "mix.lock" }}
               paths:
@@ -69,19 +57,15 @@ workflows:
           name: "1.8-otp-21"
           elixir: "1.8.1"
           otp: "21"
-          codecov_flag: "1_8_otp21"
       - telemetry_metrics_statsd/build_and_test:
           name: "1.8-otp-20"
           elixir: "1.8.1"
           otp: "20"
-          codecov_flag: "1_8_otp19"
       - telemetry_metrics_statsd/build_and_test:
           name: "1.5-otp-20"
           elixir: "1.5.3"
           otp: "20"
-          codecov_flag: "1_5_otp20"
       - telemetry_metrics_statsd/build_and_test:
           name: "1.5-otp-18"
           elixir: "1.5.3"
           otp: "18"
-          codecov_flag: "1_5_otp18"

--- a/lib/telemetry_metrics_statsd.ex
+++ b/lib/telemetry_metrics_statsd.ex
@@ -18,10 +18,14 @@ defmodule TelemetryMetricsStatsd do
   alias TelemetryMetricsStatsd.{EventHandler, UDP}
 
   @type option ::
-          {:port, :inet.port_number()} | {:host, String.t()} | {:metrics, [Metrics.t()]}
+          {:port, :inet.port_number()}
+          | {:host, String.t()}
+          | {:metrics, [Metrics.t()]}
+          | {:mtu, non_neg_integer()}
   @type options :: [option]
 
   @default_port 8125
+  @default_mtu 512
 
   @doc """
   Reporter's child spec.
@@ -62,10 +66,11 @@ defmodule TelemetryMetricsStatsd do
     metrics = Keyword.fetch!(options, :metrics)
     port = Keyword.get(options, :port, @default_port)
     host = Keyword.get(options, :host, "localhost") |> to_charlist()
+    mtu = Keyword.get(options, :mtu, @default_mtu)
 
     case UDP.open(host, port) do
       {:ok, udp} ->
-        handler_ids = EventHandler.attach(metrics, self())
+        handler_ids = EventHandler.attach(metrics, self(), mtu)
         {:ok, %{udp: udp, handler_ids: handler_ids, host: host, port: port}}
 
       {:error, reason} ->
@@ -80,12 +85,14 @@ defmodule TelemetryMetricsStatsd do
 
   @impl true
   def handle_cast({:udp_error, udp, reason}, %{udp: udp} = state) do
-    Logger.error "Failed to publish metrics over UDP: #{inspect reason}"
+    Logger.error("Failed to publish metrics over UDP: #{inspect(reason)}")
+
     case UDP.open(state.host, state.port) do
       {:ok, udp} ->
         {:noreply, %{state | udp: udp}}
+
       {:error, reason} ->
-        Logger.error "Failed to reopen UDP socket: #{inspect reason}"
+        Logger.error("Failed to reopen UDP socket: #{inspect(reason)}")
         {:stop, {:udp_open_failed, reason}, state}
     end
   end

--- a/lib/telemetry_metrics_statsd.ex
+++ b/lib/telemetry_metrics_statsd.ex
@@ -97,6 +97,10 @@ defmodule TelemetryMetricsStatsd do
     end
   end
 
+  def handle_cast({:udp_error, _, _}, state) do
+    {:noreply, state}
+  end
+
   @impl true
   def terminate(_reason, state) do
     EventHandler.detach(state.handler_ids)

--- a/lib/telemetry_metrics_statsd/event_handler.ex
+++ b/lib/telemetry_metrics_statsd/event_handler.ex
@@ -2,10 +2,10 @@ defmodule TelemetryMetricsStatsd.EventHandler do
   @moduledoc false
 
   alias Telemetry.Metrics
-  alias TelemetryMetricsStatsd.{Formatter, UDP}
+  alias TelemetryMetricsStatsd.{Formatter, Packet, UDP}
 
-  @spec attach([Metrics.t()], reporter :: pid()) :: [:telemetry.handler_id()]
-  def attach(metrics, reporter) do
+  @spec attach([Metrics.t()], reporter :: pid(), mtu :: non_neg_integer()) :: [:telemetry.handler_id()]
+  def attach(metrics, reporter, mtu) do
     metrics_by_event = Enum.group_by(metrics, & &1.event_name)
 
     for {event_name, metrics} <- metrics_by_event do
@@ -14,7 +14,8 @@ defmodule TelemetryMetricsStatsd.EventHandler do
       :ok =
         :telemetry.attach(handler_id, event_name, &handle_event/4, %{
           reporter: reporter,
-          metrics: metrics
+          metrics: metrics,
+          mtu: mtu
         })
 
       handler_id
@@ -26,11 +27,16 @@ defmodule TelemetryMetricsStatsd.EventHandler do
     for handler_id <- handler_ids do
       :telemetry.detach(handler_id)
     end
+
     :ok
   end
 
-  defp handle_event(_event, measurements, metadata, %{reporter: reporter, metrics: metrics}) do
-    payload =
+  defp handle_event(_event, measurements, metadata, %{
+         reporter: reporter,
+         metrics: metrics,
+         mtu: mtu
+       }) do
+    packets =
       for metric <- metrics do
         case fetch_measurement(metric, measurements) do
           {:ok, value} ->
@@ -44,10 +50,9 @@ defmodule TelemetryMetricsStatsd.EventHandler do
         end
       end
       |> Enum.filter(fn l -> l != :nopublish end)
-      # TODO: chunk the packets per MTU size.
-      |> Enum.join("\n")
+      |> Packet.build_packets(mtu, "\n")
 
-    publish_metrics(reporter, payload)
+    publish_metrics(reporter, packets)
   end
 
   @spec handler_id(:telemetry.event_name(), reporter :: pid) :: :telemetry.handler_id()
@@ -80,14 +85,19 @@ defmodule TelemetryMetricsStatsd.EventHandler do
     end
   end
 
-  @spec publish_metrics(pid(), binary()) :: :ok
-  defp publish_metrics(reporter, payload) do
+  @spec publish_metrics(pid(), [binary()]) :: :ok
+  defp publish_metrics(reporter, packets) do
     udp = TelemetryMetricsStatsd.get_udp(reporter)
-    case UDP.send(udp, payload) do
-      :ok ->
-        :ok
-      {:error, reason} ->
-        TelemetryMetricsStatsd.udp_error(reporter, udp, reason)
-    end
+
+    Enum.reduce_while(packets, :cont, fn packet, :cont ->
+      case UDP.send(udp, packet) do
+        :ok ->
+          {:cont, :cont}
+
+        {:error, reason} ->
+          TelemetryMetricsStatsd.udp_error(reporter, udp, reason)
+          {:halt, :halt}
+      end
+    end)
   end
 end

--- a/lib/telemetry_metrics_statsd/event_handler.ex
+++ b/lib/telemetry_metrics_statsd/event_handler.ex
@@ -41,8 +41,8 @@ defmodule TelemetryMetricsStatsd.EventHandler do
         case fetch_measurement(metric, measurements) do
           {:ok, value} ->
             # The order of tags needs to be preserved so that the final metric name is built correctly.
-            final_metadata = metric.metadata.(metadata)
-            tags = Enum.map(metric.tags, &{&1, Map.fetch!(final_metadata, &1)})
+            tag_values = metric.tag_values.(metadata)
+            tags = Enum.map(metric.tags, &{&1, Map.fetch!(tag_values, &1)})
             Formatter.format(metric, value, tags)
 
           :error ->

--- a/lib/telemetry_metrics_statsd/event_handler.ex
+++ b/lib/telemetry_metrics_statsd/event_handler.ex
@@ -4,7 +4,9 @@ defmodule TelemetryMetricsStatsd.EventHandler do
   alias Telemetry.Metrics
   alias TelemetryMetricsStatsd.{Formatter, Packet, UDP}
 
-  @spec attach([Metrics.t()], reporter :: pid(), mtu :: non_neg_integer()) :: [:telemetry.handler_id()]
+  @spec attach([Metrics.t()], reporter :: pid(), mtu :: non_neg_integer()) :: [
+          :telemetry.handler_id()
+        ]
   def attach(metrics, reporter, mtu) do
     metrics_by_event = Enum.group_by(metrics, & &1.event_name)
 

--- a/lib/telemetry_metrics_statsd/formatter.ex
+++ b/lib/telemetry_metrics_statsd/formatter.ex
@@ -9,9 +9,10 @@ defmodule TelemetryMetricsStatsd.Formatter do
           tags :: [
             {Telemetry.Metrics.tag(), term()}
           ]
-        ) :: iodata()
+        ) :: binary()
   def format(metric, value, tags) do
     [format_metric_name(metric.name, tags), ?:, format_metric_value(metric, value)]
+    |> :erlang.iolist_to_binary()
   end
 
   defp format_metric_name(metric_name, tags) do

--- a/lib/telemetry_metrics_statsd/packet.ex
+++ b/lib/telemetry_metrics_statsd/packet.ex
@@ -1,0 +1,54 @@
+defmodule TelemetryMetricsStatsd.Packet do
+  @moduledoc false
+
+  @spec build_packets([binary()], size :: non_neg_integer(), joiner :: binary()) :: [binary()]
+  def build_packets(binaries, max_size, joiner)
+      when is_integer(max_size) and max_size > 0 and is_binary(joiner) do
+    build_packets(binaries, max_size, {joiner, byte_size(joiner)}, [{[], 0, 0}])
+  end
+
+  # Only the first element of `acc` is a pair of packet and its size.
+  def build_packets([], _, {joiner, _}, [{packet_binaries, _, _} | acc]) do
+    packet =
+      packet_binaries
+      |> :lists.reverse()
+      |> Enum.intersperse(joiner)
+      |> :erlang.iolist_to_binary()
+
+    :lists.reverse([packet | acc])
+  end
+
+  def build_packets([binary | binaries], max_size, {joiner, joiner_size}, [
+        {packet_binaries, packet_binaries_count, packet_binaries_size} | acc
+      ]) do
+    binary_size = byte_size(binary)
+
+    if binary_size > max_size do
+      # TODO: this should be probably handled in a nicer way
+      raise "Binary size exceeds the provided maximum packet size"
+    end
+
+    new_packet_binaries_count = packet_binaries_count + 1
+    new_packet_binaries_size = packet_binaries_size + binary_size
+    packet_size = new_packet_binaries_size + (new_packet_binaries_count - 1) * joiner_size
+
+    if packet_size <= max_size do
+      packet_binaries = [binary | packet_binaries]
+
+      build_packets(binaries, max_size, {joiner, joiner_size}, [
+        {packet_binaries, new_packet_binaries_count, new_packet_binaries_size} | acc
+      ])
+    else
+      packet =
+        packet_binaries
+        |> :lists.reverse()
+        |> Enum.intersperse(joiner)
+        |> :erlang.iolist_to_binary()
+
+      build_packets([binary | binaries], max_size, {joiner, joiner_size}, [
+        {[], 0, 0},
+        packet | acc
+      ])
+    end
+  end
+end

--- a/mix.exs
+++ b/mix.exs
@@ -32,7 +32,7 @@ defmodule TelemetryMetricsStatsd.MixProject do
       {:telemetry, "~> 0.4"},
       {:telemetry_metrics, github: "beam-telemetry/telemetry_metrics"},
       {:stream_data, "~> 0.4", only: :test},
-      {:dialyxir, "~> 1.0.0-rc.3", only: :test, runtime: false},
+      {:dialyxir, "~> 0.5", only: :test, runtime: false},
       {:excoveralls, "~> 0.10.0", only: :test, runtime: false}
     ]
   end

--- a/mix.exs
+++ b/mix.exs
@@ -32,8 +32,7 @@ defmodule TelemetryMetricsStatsd.MixProject do
       {:telemetry, "~> 0.4"},
       {:telemetry_metrics, github: "beam-telemetry/telemetry_metrics"},
       {:stream_data, "~> 0.4", only: :test},
-      {:dialyxir, "~> 0.5", only: :test, runtime: false},
-      {:excoveralls, "~> 0.10.0", only: :test, runtime: false}
+      {:dialyxir, "~> 0.5", only: :test, runtime: false}
     ]
   end
 end

--- a/mix.exs
+++ b/mix.exs
@@ -31,6 +31,7 @@ defmodule TelemetryMetricsStatsd.MixProject do
     [
       {:telemetry, "~> 0.4"},
       {:telemetry_metrics, github: "beam-telemetry/telemetry_metrics"},
+      {:stream_data, "~> 0.4", only: :test},
       {:dialyxir, "~> 1.0.0-rc.3", only: :test, runtime: false},
       {:excoveralls, "~> 0.10.0", only: :test, runtime: false}
     ]

--- a/mix.lock
+++ b/mix.lock
@@ -1,8 +1,6 @@
-%{
-  "certifi": {:hex, :certifi, "2.5.1", "867ce347f7c7d78563450a18a6a28a8090331e77fa02380b4a21962a65d36ee5", [:rebar3], [{:parse_trans, "~>3.3", [hex: :parse_trans, repo: "hexpm", optional: false]}], "hexpm"},
+%{"certifi": {:hex, :certifi, "2.5.1", "867ce347f7c7d78563450a18a6a28a8090331e77fa02380b4a21962a65d36ee5", [:rebar3], [{:parse_trans, "~>3.3", [hex: :parse_trans, repo: "hexpm", optional: false]}], "hexpm"},
   "dialyxir": {:hex, :dialyxir, "0.5.1", "b331b091720fd93e878137add264bac4f644e1ddae07a70bf7062c7862c4b952", [:mix], [], "hexpm"},
   "erlex": {:hex, :erlex, "0.2.1", "cee02918660807cbba9a7229cae9b42d1c6143b768c781fa6cee1eaf03ad860b", [:mix], [], "hexpm"},
-  "excoveralls": {:hex, :excoveralls, "0.10.5", "7c912c4ec0715a6013647d835c87cde8154855b9b84e256bc7a63858d5f284e3", [:mix], [{:hackney, "~> 1.13", [hex: :hackney, repo: "hexpm", optional: false]}, {:jason, "~> 1.0", [hex: :jason, repo: "hexpm", optional: false]}], "hexpm"},
   "hackney": {:hex, :hackney, "1.15.1", "9f8f471c844b8ce395f7b6d8398139e26ddca9ebc171a8b91342ee15a19963f4", [:rebar3], [{:certifi, "2.5.1", [hex: :certifi, repo: "hexpm", optional: false]}, {:idna, "6.0.0", [hex: :idna, repo: "hexpm", optional: false]}, {:metrics, "1.0.1", [hex: :metrics, repo: "hexpm", optional: false]}, {:mimerl, "~>1.1", [hex: :mimerl, repo: "hexpm", optional: false]}, {:ssl_verify_fun, "1.1.4", [hex: :ssl_verify_fun, repo: "hexpm", optional: false]}], "hexpm"},
   "idna": {:hex, :idna, "6.0.0", "689c46cbcdf3524c44d5f3dde8001f364cd7608a99556d8fbd8239a5798d4c10", [:rebar3], [{:unicode_util_compat, "0.4.1", [hex: :unicode_util_compat, repo: "hexpm", optional: false]}], "hexpm"},
   "jason": {:hex, :jason, "1.1.2", "b03dedea67a99223a2eaf9f1264ce37154564de899fd3d8b9a21b1a6fd64afe7", [:mix], [{:decimal, "~> 1.0", [hex: :decimal, repo: "hexpm", optional: true]}], "hexpm"},
@@ -13,5 +11,4 @@
   "stream_data": {:hex, :stream_data, "0.4.2", "fa86b78c88ec4eaa482c0891350fcc23f19a79059a687760ddcf8680aac2799b", [:mix], [], "hexpm"},
   "telemetry": {:hex, :telemetry, "0.4.0", "8339bee3fa8b91cb84d14c2935f8ecf399ccd87301ad6da6b71c09553834b2ab", [:rebar3], [], "hexpm"},
   "telemetry_metrics": {:git, "https://github.com/beam-telemetry/telemetry_metrics.git", "6bf94c68369591133ccec5e4d8674eb85686f4d4", []},
-  "unicode_util_compat": {:hex, :unicode_util_compat, "0.4.1", "d869e4c68901dd9531385bb0c8c40444ebf624e60b6962d95952775cac5e90cd", [:rebar3], [], "hexpm"},
-}
+  "unicode_util_compat": {:hex, :unicode_util_compat, "0.4.1", "d869e4c68901dd9531385bb0c8c40444ebf624e60b6962d95952775cac5e90cd", [:rebar3], [], "hexpm"}}

--- a/mix.lock
+++ b/mix.lock
@@ -10,7 +10,8 @@
   "mimerl": {:hex, :mimerl, "1.2.0", "67e2d3f571088d5cfd3e550c383094b47159f3eee8ffa08e64106cdf5e981be3", [:rebar3], [], "hexpm"},
   "parse_trans": {:hex, :parse_trans, "3.3.0", "09765507a3c7590a784615cfd421d101aec25098d50b89d7aa1d66646bc571c1", [:rebar3], [], "hexpm"},
   "ssl_verify_fun": {:hex, :ssl_verify_fun, "1.1.4", "f0eafff810d2041e93f915ef59899c923f4568f4585904d010387ed74988e77b", [:make, :mix, :rebar3], [], "hexpm"},
+  "stream_data": {:hex, :stream_data, "0.4.2", "fa86b78c88ec4eaa482c0891350fcc23f19a79059a687760ddcf8680aac2799b", [:mix], [], "hexpm"},
   "telemetry": {:hex, :telemetry, "0.4.0", "8339bee3fa8b91cb84d14c2935f8ecf399ccd87301ad6da6b71c09553834b2ab", [:rebar3], [], "hexpm"},
-  "telemetry_metrics": {:git, "https://github.com/beam-telemetry/telemetry_metrics.git", "d0aa30687955ddc3eb073ec4a611e67594839090", []},
+  "telemetry_metrics": {:git, "https://github.com/beam-telemetry/telemetry_metrics.git", "6bf94c68369591133ccec5e4d8674eb85686f4d4", []},
   "unicode_util_compat": {:hex, :unicode_util_compat, "0.4.1", "d869e4c68901dd9531385bb0c8c40444ebf624e60b6962d95952775cac5e90cd", [:rebar3], [], "hexpm"},
 }

--- a/mix.lock
+++ b/mix.lock
@@ -1,6 +1,6 @@
 %{
   "certifi": {:hex, :certifi, "2.5.1", "867ce347f7c7d78563450a18a6a28a8090331e77fa02380b4a21962a65d36ee5", [:rebar3], [{:parse_trans, "~>3.3", [hex: :parse_trans, repo: "hexpm", optional: false]}], "hexpm"},
-  "dialyxir": {:hex, :dialyxir, "1.0.0-rc.4", "71b42f5ee1b7628f3e3a6565f4617dfb02d127a0499ab3e72750455e986df001", [:mix], [{:erlex, "~> 0.1", [hex: :erlex, repo: "hexpm", optional: false]}], "hexpm"},
+  "dialyxir": {:hex, :dialyxir, "0.5.1", "b331b091720fd93e878137add264bac4f644e1ddae07a70bf7062c7862c4b952", [:mix], [], "hexpm"},
   "erlex": {:hex, :erlex, "0.2.1", "cee02918660807cbba9a7229cae9b42d1c6143b768c781fa6cee1eaf03ad860b", [:mix], [], "hexpm"},
   "excoveralls": {:hex, :excoveralls, "0.10.5", "7c912c4ec0715a6013647d835c87cde8154855b9b84e256bc7a63858d5f284e3", [:mix], [{:hackney, "~> 1.13", [hex: :hackney, repo: "hexpm", optional: false]}, {:jason, "~> 1.0", [hex: :jason, repo: "hexpm", optional: false]}], "hexpm"},
   "hackney": {:hex, :hackney, "1.15.1", "9f8f471c844b8ce395f7b6d8398139e26ddca9ebc171a8b91342ee15a19963f4", [:rebar3], [{:certifi, "2.5.1", [hex: :certifi, repo: "hexpm", optional: false]}, {:idna, "6.0.0", [hex: :idna, repo: "hexpm", optional: false]}, {:metrics, "1.0.1", [hex: :metrics, repo: "hexpm", optional: false]}, {:mimerl, "~>1.1", [hex: :mimerl, repo: "hexpm", optional: false]}, {:ssl_verify_fun, "1.1.4", [hex: :ssl_verify_fun, repo: "hexpm", optional: false]}], "hexpm"},

--- a/test/telemetry_metrics_statsd/packet_test.exs
+++ b/test/telemetry_metrics_statsd/packet_test.exs
@@ -10,28 +10,26 @@ defmodule TelemetryMetricsStatsd.PacketTest do
               # know that we won't be using the in the case of StatsD packets.
               binaries <- list_of(binary(min_length: 1, max_length: max_packet_size)),
               joiner <- binary() do
-
       packets = Packet.build_packets(binaries, max_packet_size, joiner)
 
-      for packet <- packets, reduce: binaries do
-        binaries ->
-          # each packet needs to be smaller or equal in size to the max_packet_size
-          packet_size = byte_size(packet)
-          assert packet_size <= max_packet_size
-          binaries = drop_packet_binaries(packet, joiner, binaries)
+      Enum.reduce(packets, binaries, fn packet, binaries ->
+        # each packet needs to be smaller or equal in size to the max_packet_size
+        packet_size = byte_size(packet)
+        assert packet_size <= max_packet_size
+        binaries = drop_packet_binaries(packet, joiner, binaries)
 
-          if binaries != [] do
-            # but the packet needs to be as big as possible
-            next_binary = Enum.at(binaries, 0)
+        if binaries != [] do
+          # but the packet needs to be as big as possible
+          next_binary = Enum.at(binaries, 0)
 
-            assert byte_size(packet <> joiner <> next_binary) > max_packet_size,
-                   "packets: #{inspect(packets)}, packet: #{inspect(packet)}, next_binary: #{
-                     inspect(next_binary)
-                   }, left binaries: #{inspect(binaries)}, packet_size: #{packet_size}"
-          end
+          assert byte_size(packet <> joiner <> next_binary) > max_packet_size,
+                 "packets: #{inspect(packets)}, packet: #{inspect(packet)}, next_binary: #{
+                   inspect(next_binary)
+                 }, left binaries: #{inspect(binaries)}, packet_size: #{packet_size}"
+        end
 
-          binaries
-      end
+        binaries
+      end)
     end
   end
 

--- a/test/telemetry_metrics_statsd/packet_test.exs
+++ b/test/telemetry_metrics_statsd/packet_test.exs
@@ -1,0 +1,59 @@
+defmodule TelemetryMetricsStatsd.PacketTest do
+  use ExUnit.Case, async: true
+  use ExUnitProperties
+
+  alias TelemetryMetricsStatsd.Packet
+
+  property "it returns packets of binaries under given size joined with given binary" do
+    check all max_packet_size <- positive_integer(),
+              # We should consider empty binaries in general case, but let's ignore them since we
+              # know that we won't be using the in the case of StatsD packets.
+              binaries <- list_of(binary(min_length: 1, max_length: max_packet_size)),
+              joiner <- binary() do
+
+      packets = Packet.build_packets(binaries, max_packet_size, joiner)
+
+      for packet <- packets, reduce: binaries do
+        binaries ->
+          # each packet needs to be smaller or equal in size to the max_packet_size
+          packet_size = byte_size(packet)
+          assert packet_size <= max_packet_size
+          binaries = drop_packet_binaries(packet, joiner, binaries)
+
+          if binaries != [] do
+            # but the packet needs to be as big as possible
+            next_binary = Enum.at(binaries, 0)
+
+            assert byte_size(packet <> joiner <> next_binary) > max_packet_size,
+                   "packets: #{inspect(packets)}, packet: #{inspect(packet)}, next_binary: #{
+                     inspect(next_binary)
+                   }, left binaries: #{inspect(binaries)}, packet_size: #{packet_size}"
+          end
+
+          binaries
+      end
+    end
+  end
+
+  defp drop_packet_binaries(packet, joiner, binaries, binaries_so_far \\ [])
+
+  defp drop_packet_binaries(_, _, [], _) do
+    []
+  end
+
+  defp drop_packet_binaries(packet, joiner, [binary | binaries], binaries_so_far) do
+    packet_so_far =
+      binaries_so_far
+      |> Enum.intersperse(joiner)
+      |> :lists.reverse()
+      |> :erlang.iolist_to_binary()
+
+    cond do
+      packet_so_far == packet ->
+        [binary | binaries]
+
+      true ->
+        drop_packet_binaries(packet, joiner, binaries, [binary | binaries_so_far])
+    end
+  end
+end

--- a/test/telemetry_metrics_statsd_test.exs
+++ b/test/telemetry_metrics_statsd_test.exs
@@ -52,7 +52,8 @@ defmodule TelemetryMetricsStatsdTest do
     {socket, port} = given_udp_port_opened()
 
     dist =
-      given_distribution("http.request.latency",
+      given_distribution(
+        "http.request.latency",
         buckets: [0, 100, 200, 300]
       )
 
@@ -71,7 +72,8 @@ defmodule TelemetryMetricsStatsdTest do
     {socket, port} = given_udp_port_opened()
 
     counter =
-      given_counter("http.requests",
+      given_counter(
+        "http.requests",
         event_name: "http.request",
         metadata: :all,
         tags: [:method, :status]
@@ -107,7 +109,8 @@ defmodule TelemetryMetricsStatsdTest do
     {socket, port} = given_udp_port_opened()
 
     dist =
-      given_distribution("http.request.latency",
+      given_distribution(
+        "http.request.latency",
         buckets: [0, 100, 200, 300]
       )
 
@@ -121,20 +124,17 @@ defmodule TelemetryMetricsStatsdTest do
 
     assert_reported(
       socket,
-      "http.request.latency:172|ms\n" <>
-        "http.request.payload_size:+121|g"
+      "http.request.latency:172|ms\n" <> "http.request.payload_size:+121|g"
     )
 
     assert_reported(
       socket,
-      "http.request.latency:200|ms\n" <>
-        "http.request.payload_size:+64|g"
+      "http.request.latency:200|ms\n" <> "http.request.payload_size:+64|g"
     )
 
     assert_reported(
       socket,
-      "http.request.latency:198|ms\n" <>
-        "http.request.payload_size:+1021|g"
+      "http.request.latency:198|ms\n" <> "http.request.payload_size:+1021|g"
     )
   end
 
@@ -154,14 +154,12 @@ defmodule TelemetryMetricsStatsdTest do
 
     assert_reported(
       socket,
-      "first.counter:1|c\n" <>
-        "second.counter:1|c"
+      "first.counter:1|c\n" <> "second.counter:1|c"
     )
 
     assert_reported(
       socket,
-      "third.counter:1|c\n" <>
-        "fourth.counter:1|c"
+      "third.counter:1|c\n" <> "fourth.counter:1|c"
     )
   end
 
@@ -187,7 +185,7 @@ defmodule TelemetryMetricsStatsdTest do
                Process.sleep(100)
              end) =~ ~r/\[error\] Failed to publish metrics over UDP: :closed/
 
-      refute capture_log(fn ->
+      assert capture_log(fn ->
                TelemetryMetricsStatsd.udp_error(reporter, udp, :closed)
                Process.sleep(100)
              end) == ""
@@ -228,7 +226,8 @@ defmodule TelemetryMetricsStatsdTest do
   end
 
   defp start_reporter(options) do
-    start_supervised!({TelemetryMetricsStatsd, options})
+    {:ok, pid} = TelemetryMetricsStatsd.start_link(options)
+    pid
   end
 
   defp assert_reported(socket, expected_payload) do

--- a/test/telemetry_metrics_statsd_test.exs
+++ b/test/telemetry_metrics_statsd_test.exs
@@ -139,7 +139,6 @@ defmodule TelemetryMetricsStatsdTest do
   end
 
   describe "UDP error handling" do
-    @tag :error_handling
     test "notifying a UDP error logs an error" do
       reporter = start_reporter(metrics: [])
       udp = TelemetryMetricsStatsd.get_udp(reporter)


### PR DESCRIPTION
This is especially important in case of UDP, where each packet needs to fit into a single IP datagram (there is no control flow mechanism to ensure that packets are "whole").

I've also updated to the newest Telemetry.Metrics and made some changes so that the tests run on Elixir 1.5.