### PR TITLE
Small doc fix

### DIFF
--- a/lib/telemetry_metrics_statsd.ex
+++ b/lib/telemetry_metrics_statsd.ex
@@ -60,7 +60,7 @@ defmodule TelemetryMetricsStatsd do
 
   and the event
 
-      :telemetry.execute([:http, :request], %{duration: 120})
+      :telemetry.execute([:http, :request], %{count: 1})
 
   the following line would be send to StatsD
 


### PR DESCRIPTION
Just noticed this small mismatch in the docs. Also is there any reason for 

```elixir
  defp format_metric_value(%Metrics.Counter{}, _value), do: "1|c"
```

So basically the value of the counter is always ignored?
