### PR TITLE
Add support for datadog style tags

### DIFF
--- a/test/telemetry_metrics_statsd_test.exs
+++ b/test/telemetry_metrics_statsd_test.exs
@@ -91,7 +91,7 @@ defmodule TelemetryMetricsStatsdTest do
     assert_reported(socket, "http.requests.GET.404:1|c")
   end
 
-  test "StatsD metric can be reported with StatsD tags" do
+  test "StatsD metric can be reported with DataDog style StatsD tags" do
     {socket, port} = given_udp_port_opened()
 
     counter =


### PR DESCRIPTION
StatsD does not have a standard tags format. DataDog format is very popular, but won't work for all tools.

The `tag_format` option is extendable so that other tag formats could be supported.