### PR TITLE
Support summary metric

### DIFF
--- a/lib/telemetry_metrics_statsd.ex
+++ b/lib/telemetry_metrics_statsd.ex
@@ -104,6 +104,21 @@ defmodule TelemetryMetricsStatsd do
 
   When the measurement is negative, the StatsD gauge is decreased accordingly.
 
+  ### Summary
+
+  The summary is simply represented as a StatsD timer, since it should generate statistics about
+  gathered measurements. Given the metric definition below
+
+      summary("http.request.duration")
+
+  and the event
+
+      :telemetry.execute([:http, :request], %{duration: 120})
+
+  the following line would be send to StatsD
+
+      "http.request.duration:120|ms"
+
   ### Distribution
 
   There is no metric in StatsD (or at least in the

--- a/lib/telemetry_metrics_statsd/formatter.ex
+++ b/lib/telemetry_metrics_statsd/formatter.ex
@@ -4,7 +4,7 @@ defmodule TelemetryMetricsStatsd.Formatter do
   alias Telemetry.Metrics
 
   @spec format(
-          prefix :: String.t | nil,
+          prefix :: String.t() | nil,
           Telemetry.Metrics.t(),
           :telemetry.event_value(),
           tags :: [
@@ -17,7 +17,9 @@ defmodule TelemetryMetricsStatsd.Formatter do
   end
 
   defp format_metric_name(nil, metric_name, tags), do: format_metric_name(metric_name, tags)
-  defp format_metric_name(prefix, metric_name, tags), do: format_metric_name([prefix | metric_name], tags)
+
+  defp format_metric_name(prefix, metric_name, tags),
+    do: format_metric_name([prefix | metric_name], tags)
 
   defp format_metric_name(metric_name, tags) do
     segments = metric_name ++ Enum.map(tags, fn {_, tag_value} -> tag_value end)
@@ -28,6 +30,7 @@ defmodule TelemetryMetricsStatsd.Formatter do
   end
 
   defp format_metric_value(%Metrics.Counter{}, _value), do: "1|c"
+  defp format_metric_value(%Metrics.Summary{}, value), do: "#{value}|ms"
   defp format_metric_value(%Metrics.Distribution{}, value), do: "#{value}|ms"
   defp format_metric_value(%Metrics.LastValue{}, value), do: "#{value}|g"
   defp format_metric_value(%Metrics.Sum{}, value) when value >= 0, do: "+#{value}|g"

--- a/mix.exs
+++ b/mix.exs
@@ -37,7 +37,7 @@ defmodule TelemetryMetricsStatsd.MixProject do
 
   defp deps do
     [
-      {:telemetry_metrics, "~> 0.2"},
+      {:telemetry_metrics, "~> 0.3"},
       {:stream_data, "~> 0.4", only: :test},
       {:dialyxir, "~> 0.5", only: :test, runtime: false},
       {:ex_doc, "~> 0.19", only: :docs}

--- a/mix.lock
+++ b/mix.lock
@@ -16,6 +16,6 @@
   "ssl_verify_fun": {:hex, :ssl_verify_fun, "1.1.4", "f0eafff810d2041e93f915ef59899c923f4568f4585904d010387ed74988e77b", [:make, :mix, :rebar3], [], "hexpm"},
   "stream_data": {:hex, :stream_data, "0.4.2", "fa86b78c88ec4eaa482c0891350fcc23f19a79059a687760ddcf8680aac2799b", [:mix], [], "hexpm"},
   "telemetry": {:hex, :telemetry, "0.4.0", "8339bee3fa8b91cb84d14c2935f8ecf399ccd87301ad6da6b71c09553834b2ab", [:rebar3], [], "hexpm"},
-  "telemetry_metrics": {:hex, :telemetry_metrics, "0.2.0", "caf60031ed8b71facc2c3e4eee4ae4640deb2eb5ad9d641e55d6051539f64f01", [:mix], [{:telemetry, "~> 0.4", [hex: :telemetry, repo: "hexpm", optional: false]}], "hexpm"},
+  "telemetry_metrics": {:hex, :telemetry_metrics, "0.3.0", "5de4037d058faf6355835c0ec65ff19605258ee696fa9f93304a389d2d497445", [:mix], [{:telemetry, "~> 0.4", [hex: :telemetry, repo: "hexpm", optional: false]}], "hexpm"},
   "unicode_util_compat": {:hex, :unicode_util_compat, "0.4.1", "d869e4c68901dd9531385bb0c8c40444ebf624e60b6962d95952775cac5e90cd", [:rebar3], [], "hexpm"},
 }


### PR DESCRIPTION
This adds support for summary metric introduced in Telemetry.Metrics v0.3.0. Also, the requirement for `telemetry_metrics` dependency has been bumped.