### PR TITLE
allow default tags

### DIFF
--- a/lib/telemetry_metrics_statsd.ex
+++ b/lib/telemetry_metrics_statsd.ex
@@ -207,7 +207,7 @@ defmodule TelemetryMetricsStatsd do
           | {:mtu, non_neg_integer()}
           | {:prefix, prefix()}
           | {:formatter, :standard | :datadog}
-          | {:default_tags, Keyword.t()}
+          | {:global_tags, Keyword.t()}
   @type options :: [option]
 
   @default_port 8125
@@ -245,7 +245,7 @@ defmodule TelemetryMetricsStatsd do
   * `:mtu` - Maximum Transmission Unit of the link between your application and the StatsD server in
     bytes. This value should not be greater than the actual MTU since this could lead to the data loss
     when the metrics are published. Defaults to `512`.
-  * `:default_tags` - Additional default tag values to be sent along with every published metric. These
+  * `:global_tags` - Additional default tag values to be sent along with every published metric. These
     can be overriden by tags sent via the `:telemetry.execute` call.
 
   You can read more about all the options in the `TelemetryMetricsStatsd` module documentation.
@@ -275,7 +275,7 @@ defmodule TelemetryMetricsStatsd do
       |> Map.put_new(:prefix, nil)
       |> Map.put_new(:formatter, @default_formatter)
       |> Map.update!(:formatter, &validate_and_translate_formatter/1)
-      |> Map.put_new(:default_tags, Keyword.new())
+      |> Map.put_new(:global_tags, Keyword.new())
 
     GenServer.start_link(__MODULE__, config)
   end
@@ -301,7 +301,7 @@ defmodule TelemetryMetricsStatsd do
         Process.flag(:trap_exit, true)
 
         handler_ids =
-          EventHandler.attach(metrics, self(), config.mtu, config.prefix, config.formatter, config.default_tags)
+          EventHandler.attach(metrics, self(), config.mtu, config.prefix, config.formatter, config.global_tags)
 
         {:ok, %{udp: udp, handler_ids: handler_ids, host: config.host, port: config.port}}
 

--- a/lib/telemetry_metrics_statsd/event_handler.ex
+++ b/lib/telemetry_metrics_statsd/event_handler.ex
@@ -9,11 +9,12 @@ defmodule TelemetryMetricsStatsd.EventHandler do
           reporter :: pid(),
           mtu :: non_neg_integer(),
           prefix :: String.t() | nil,
-          formatter :: Formatter.t()
+          formatter :: Formatter.t(),
+          default_tags :: Keyword.t()
         ) :: [
           :telemetry.handler_id()
         ]
-  def attach(metrics, reporter, mtu, prefix, formatter) do
+  def attach(metrics, reporter, mtu, prefix, formatter, default_tags) do
     metrics_by_event = Enum.group_by(metrics, & &1.event_name)
 
     for {event_name, metrics} <- metrics_by_event do
@@ -25,7 +26,8 @@ defmodule TelemetryMetricsStatsd.EventHandler do
           metrics: metrics,
           mtu: mtu,
           prefix: prefix,
-          formatter: formatter
+          formatter: formatter,
+          default_tags: default_tags
         })
 
       handler_id
@@ -46,7 +48,8 @@ defmodule TelemetryMetricsStatsd.EventHandler do
         metrics: metrics,
         mtu: mtu,
         prefix: prefix,
-        formatter: formatter_mod
+        formatter: formatter_mod,
+        default_tags: default_tags
       }) do
     packets =
       for metric <- metrics do
@@ -54,7 +57,8 @@ defmodule TelemetryMetricsStatsd.EventHandler do
           {:ok, value} ->
             # The order of tags needs to be preserved so that the final metric name is built correctly.
             tag_values = metric.tag_values.(metadata)
-            tags = Enum.map(metric.tags, &{&1, Map.fetch!(tag_values, &1)})
+            event_tags = Enum.map(metric.tags, &{&1, Map.fetch!(tag_values, &1)})
+            tags = Keyword.merge(default_tags, event_tags)
             Formatter.format(formatter_mod, metric, prefix, value, tags)
 
           :error ->

--- a/lib/telemetry_metrics_statsd/event_handler.ex
+++ b/lib/telemetry_metrics_statsd/event_handler.ex
@@ -10,11 +10,11 @@ defmodule TelemetryMetricsStatsd.EventHandler do
           mtu :: non_neg_integer(),
           prefix :: String.t() | nil,
           formatter :: Formatter.t(),
-          default_tags :: Keyword.t()
+          global_tags :: Keyword.t()
         ) :: [
           :telemetry.handler_id()
         ]
-  def attach(metrics, reporter, mtu, prefix, formatter, default_tags) do
+  def attach(metrics, reporter, mtu, prefix, formatter, global_tags) do
     metrics_by_event = Enum.group_by(metrics, & &1.event_name)
 
     for {event_name, metrics} <- metrics_by_event do
@@ -27,7 +27,7 @@ defmodule TelemetryMetricsStatsd.EventHandler do
           mtu: mtu,
           prefix: prefix,
           formatter: formatter,
-          default_tags: default_tags
+          global_tags: global_tags
         })
 
       handler_id
@@ -49,16 +49,18 @@ defmodule TelemetryMetricsStatsd.EventHandler do
         mtu: mtu,
         prefix: prefix,
         formatter: formatter_mod,
-        default_tags: default_tags
+        global_tags: global_tags
       }) do
     packets =
       for metric <- metrics do
         case fetch_measurement(metric, measurements) do
           {:ok, value} ->
             # The order of tags needs to be preserved so that the final metric name is built correctly.
-            tag_values = metric.tag_values.(metadata)
-            event_tags = Enum.map(metric.tags, &{&1, Map.fetch!(tag_values, &1)})
-            tags = Keyword.merge(default_tags, event_tags)
+            tag_values =
+              global_tags
+              |> Map.new()
+              |> Map.merge(metric.tag_values.(metadata))
+            tags = Enum.map(metric.tags, &{&1, Map.fetch!(tag_values, &1)})
             Formatter.format(formatter_mod, metric, prefix, value, tags)
 
           :error ->

--- a/test/telemetry_metrics_statsd_test.exs
+++ b/test/telemetry_metrics_statsd_test.exs
@@ -91,19 +91,21 @@ defmodule TelemetryMetricsStatsdTest do
       given_counter(
         "http.requests",
         event_name: "http.request",
-        tags: [:method, :status]
+        tags: [:env, :method, :status]
       )
 
     start_reporter(
       metrics: [counter],
       port: port,
       formatter: :standard,
-      default_tags: [env: "test"]
+      global_tags: [env: "test"]
     )
 
     :telemetry.execute([:http, :request], %{latency: 172}, %{method: "GET", status: 200})
+    :telemetry.execute([:http, :request], %{latency: 172}, %{env: "dev", method: "GET", status: 200})
 
     assert_reported(socket, "http.requests.test.GET.200:1|c")
+    assert_reported(socket, "http.requests.dev.GET.200:1|c")
   end
 
   test "DataDog formatter can be used" do
@@ -113,23 +115,25 @@ defmodule TelemetryMetricsStatsdTest do
       given_counter(
         "http.requests",
         event_name: "http.request",
-        tags: [:method, :status]
+        tags: [:env, :method, :status]
       )
 
     start_reporter(
       metrics: [counter],
       port: port,
       formatter: :datadog,
-      default_tags: [env: "test"]
+      global_tags: [env: "test"]
     )
 
     :telemetry.execute([:http, :request], %{latency: 172}, %{method: "GET", status: 200})
     :telemetry.execute([:http, :request], %{latency: 200}, %{method: "POST", status: 201})
     :telemetry.execute([:http, :request], %{latency: 198}, %{method: "GET", status: 404})
+    :telemetry.execute([:http, :request], %{latency: 198}, %{env: "dev", method: "GET", status: 404})
 
     assert_reported(socket, "http.requests:1|c|#env:test,method:GET,status:200")
     assert_reported(socket, "http.requests:1|c|#env:test,method:POST,status:201")
     assert_reported(socket, "http.requests:1|c|#env:test,method:GET,status:404")
+    assert_reported(socket, "http.requests:1|c|#env:dev,method:GET,status:404")
   end
 
   test "it fails to start with invalid formatter" do

--- a/test/telemetry_metrics_statsd_test.exs
+++ b/test/telemetry_metrics_statsd_test.exs
@@ -97,12 +97,13 @@ defmodule TelemetryMetricsStatsdTest do
     start_reporter(
       metrics: [counter],
       port: port,
-      formatter: :standard
+      formatter: :standard,
+      default_tags: [env: "test"]
     )
 
     :telemetry.execute([:http, :request], %{latency: 172}, %{method: "GET", status: 200})
 
-    assert_reported(socket, "http.requests.GET.200:1|c")
+    assert_reported(socket, "http.requests.test.GET.200:1|c")
   end
 
   test "DataDog formatter can be used" do
@@ -118,16 +119,17 @@ defmodule TelemetryMetricsStatsdTest do
     start_reporter(
       metrics: [counter],
       port: port,
-      formatter: :datadog
+      formatter: :datadog,
+      default_tags: [env: "test"]
     )
 
     :telemetry.execute([:http, :request], %{latency: 172}, %{method: "GET", status: 200})
     :telemetry.execute([:http, :request], %{latency: 200}, %{method: "POST", status: 201})
     :telemetry.execute([:http, :request], %{latency: 198}, %{method: "GET", status: 404})
 
-    assert_reported(socket, "http.requests:1|c|#method:GET,status:200")
-    assert_reported(socket, "http.requests:1|c|#method:POST,status:201")
-    assert_reported(socket, "http.requests:1|c|#method:GET,status:404")
+    assert_reported(socket, "http.requests:1|c|#env:test,method:GET,status:200")
+    assert_reported(socket, "http.requests:1|c|#env:test,method:POST,status:201")
+    assert_reported(socket, "http.requests:1|c|#env:test,method:GET,status:404")
   end
 
   test "it fails to start with invalid formatter" do


### PR DESCRIPTION
I wrote this for myself, and I don't know if you want something like this in the library or if other people would find it useful, but I figured I would give you the option either way.

I keep finding myself wanting to easily include information like app environment with every metric, and I don't particularly want to be making a `System.get_env` call or storing it in an agent (or `ets`), and want it quickly available each time a metric gets published. This seemed like a reasonable way to do that.

If you might want to include this and want/need edits, I'm happy to make those. If you don't want this, feel free to close the PR.

Thanks for the library, saved me a bunch of time :)